### PR TITLE
[security] bump distroless version to debian11

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Docker builds are created with [bedag/image-build](https://github.com/bedag/imag
 
 [musl compiler](https://www.musl-libc.org/how.html) is used to compile e2guardian.
 
-`gcr.io/distroless/cc` are used because we do not need any common linux binaries, [here](https://github.com/GoogleContainerTools/distroless) you can find more information about distroless images. For troubleshooting we recommend to use our `-debug` images. For more information go to [Debug](#Debug) section.
+`gcr.io/distroless/cc-debian11` are used because we do not need any common linux binaries, [here](https://github.com/GoogleContainerTools/distroless) you can find more information about distroless images. For troubleshooting we recommend to use our `-debug` images. For more information go to [Debug](#Debug) section.
 
 Every Sunday(`0 0 * * SUN`) we automatically update all [supported tags](#Tags) with the current upstream image.
 

--- a/image-build.yml
+++ b/image-build.yml
@@ -21,7 +21,7 @@ build_base: &build_base
 
 prod_base: &prod_base
   source:
-    name: "gcr.io/distroless/cc"
+    name: "gcr.io/distroless/cc-debian11"
     tags: ["latest"]
 
 debug_base: &debug_base


### PR DESCRIPTION
debian11 is fixing a lot of CVEs
#11 